### PR TITLE
ci: specify workflow permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,9 @@
 name: Pull request
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   verify:
+    permissions:
+      contents: read
     uses: ./.github/workflows/verification.yml
     secrets: inherit
 

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -2,6 +2,11 @@ name: Verification
 
 on: [workflow_call]
 
+permissions:
+  contents: read
+  actions: read
+  id-token: write
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tien/reactive-dot/security/code-scanning/3](https://github.com/tien/reactive-dot/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `actions: read` for using actions like `actions/checkout`.
- `id-token: write` for the `codecov/codecov-action` if it requires authentication.

The `permissions` block will be added after the `name` field in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
